### PR TITLE
Inactivity tax

### DIFF
--- a/dreamvisitor/src/main/java/io/github/stonley890/dreamvisitor/Dreamvisitor.java
+++ b/dreamvisitor/src/main/java/io/github/stonley890/dreamvisitor/Dreamvisitor.java
@@ -405,6 +405,8 @@ public class Dreamvisitor extends JavaPlugin {
                 }
             };
 
+            Runnable checkInactivityTax = InactivityTax::tax;
+
             Bukkit.getScheduler().runTaskTimer(this, tick, 0, 0);
 
             // Push console every two seconds
@@ -418,6 +420,9 @@ public class Dreamvisitor extends JavaPlugin {
 
             // Check for banned items every ten seconds
             Bukkit.getScheduler().runTaskTimer(this, checkBannedItems, 40, 20*10);
+
+            // Check inactivity tax every 12 hours (to account for slowdown)
+            Bukkit.getScheduler().runTaskTimer(this, checkInactivityTax, 20*60, 20*60*60*12);
 
             debug("Enable finished.");
         } catch (Exception e) {

--- a/dreamvisitor/src/main/java/io/github/stonley890/dreamvisitor/data/PlayerUtility.java
+++ b/dreamvisitor/src/main/java/io/github/stonley890/dreamvisitor/data/PlayerUtility.java
@@ -2,11 +2,14 @@ package io.github.stonley890.dreamvisitor.data;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import com.earth2me.essentials.Essentials;
 import io.github.stonley890.dreamvisitor.Dreamvisitor;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.jetbrains.annotations.Contract;
@@ -99,6 +102,7 @@ public class PlayerUtility {
         return mojang.getPlayerProfile(uuid).getUsername();
     }
 
+
     public static @Nullable UUID getUUIDOfUsername(@NotNull String username) {
         Mojang mojang = new Mojang();
         String uuid = mojang.getUUIDOfUsername(username);
@@ -108,5 +112,33 @@ public class PlayerUtility {
         } catch (IllegalArgumentException NullPointerException) {
             return null;
         }
+    }
+
+    /**
+     * Get the {@link Instant} of player's last login by UUID.
+     * @param uuid the UUID of the player.
+     * @return the {@link Instant} this player last logged in.
+     * @throws Exception if Essentials is not enabled.
+     */
+    public static @NotNull Instant getLastLogin(@NotNull UUID uuid) throws Exception {
+        Essentials ess = (Essentials) Bukkit.getPluginManager().getPlugin("Essentials");
+        if (ess == null) {
+            throw new Exception("EssentialsX is not enabled.");
+        }
+        return Instant.ofEpochMilli(ess.getUser(uuid).getLastLogin());
+    }
+
+    /**
+     * Get the {@link Instant} of player's last logout by UUID.
+     * @param uuid the UUID of the player.
+     * @return the {@link Instant} this player last logged out.
+     * @throws Exception if Essentials is not enabled.
+     */
+    public static @NotNull Instant getLastLogout(@NotNull UUID uuid) throws Exception {
+        Essentials ess = (Essentials) Bukkit.getPluginManager().getPlugin("Essentials");
+        if (ess == null) {
+            throw new Exception("EssentialsX is not enabled.");
+        }
+        return Instant.ofEpochMilli(ess.getUser(uuid).getLastLogout());
     }
 }

--- a/dreamvisitor/src/main/java/io/github/stonley890/dreamvisitor/discord/commands/DCmdSeen.java
+++ b/dreamvisitor/src/main/java/io/github/stonley890/dreamvisitor/discord/commands/DCmdSeen.java
@@ -31,11 +31,8 @@ public class DCmdSeen implements DiscordCommand {
 
     @Override
     public void onCommand(@NotNull SlashCommandInteractionEvent event) {
-        Essentials ess = (Essentials) Bukkit.getPluginManager().getPlugin("Essentials");
-        if (ess == null) {
-            event.reply("EssentialsX is not currently active!").setEphemeral(true).queue();
-            return;
-        }
+
+
         User user = event.getOption("user", OptionMapping::getAsUser);
         if (user == null) {
             event.reply("user cannot be null!").setEphemeral(true).queue();
@@ -49,13 +46,19 @@ public class DCmdSeen implements DiscordCommand {
         Dreamvisitor.debug("UUID: " + uuid);
         boolean online = Bukkit.getPlayer(uuid) != null;
         Dreamvisitor.debug("Online? " + online);
-        long time;
-        if (online) time = ess.getUser(uuid).getLastLogin();
-        else {
-            String username = PlayerUtility.getUsernameOfUuid(uuid);
-            time = ess.getOfflineUser(username).getLastLogout();
+        Instant time;
+        try {
+            if (online) {
+                time = PlayerUtility.getLastLogin(uuid);
+            } else {
+                time = PlayerUtility.getLastLogout(uuid);
+            }
+        } catch (Exception e) {
+            event.reply("EssentialsX is not currently active!").setEphemeral(true).queue();
+            return;
         }
-        Duration duration = Duration.between(Instant.ofEpochMilli(time), Instant.ofEpochMilli(System.currentTimeMillis()));
+
+        Duration duration = Duration.between(time, Instant.ofEpochMilli(System.currentTimeMillis()));
 
         EmbedBuilder embed = new EmbedBuilder();
         String status = "offline";

--- a/dreamvisitor/src/main/java/io/github/stonley890/dreamvisitor/functions/InactivityTax.java
+++ b/dreamvisitor/src/main/java/io/github/stonley890/dreamvisitor/functions/InactivityTax.java
@@ -1,0 +1,12 @@
+package io.github.stonley890.dreamvisitor.functions;
+
+public class InactivityTax {
+
+    /**
+     * This function should run once per day to tax inactive players.
+     */
+    public static void tax() {
+
+    }
+
+}

--- a/dreamvisitor/src/main/java/io/github/stonley890/dreamvisitor/functions/InactivityTax.java
+++ b/dreamvisitor/src/main/java/io/github/stonley890/dreamvisitor/functions/InactivityTax.java
@@ -1,12 +1,99 @@
 package io.github.stonley890.dreamvisitor.functions;
 
+import com.earth2me.essentials.Essentials;
+import io.github.stonley890.dreamvisitor.Dreamvisitor;
+import io.github.stonley890.dreamvisitor.data.PlayerUtility;
+import net.essentialsx.api.v2.services.BalanceTop;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.UUID;
+
 public class InactivityTax {
 
     /**
-     * This function should run once per day to tax inactive players.
+     * This function should be run at least once per day. It will not actually execute unless enough time has passed.
      */
     public static void tax() {
 
+        final Dreamvisitor plugin = Dreamvisitor.getPlugin();
+        final FileConfiguration config = plugin.getConfig();
+
+        final int taxFrequency = config.getInt("inactiveDayFrequency");
+        if (taxFrequency < 1) return; // Return if inactiveDayFrequency is 0 or less
+
+        try {
+            Instant lastTax = Instant.ofEpochMilli(config.getLong("lastInactiveTax"));
+            final Duration durationSinceLastTax = Duration.between(lastTax, Instant.now());
+            if (durationSinceLastTax.minusDays(taxFrequency).isNegative()) return; // Return if last tax was less than lastTax days ago
+        } catch (Exception ignored) {} // Exception means this has never run. So we want to run it for the first time.
+
+
+        plugin.getLogger().info("Collecting inactivity taxes");
+
+        final Essentials ess = (Essentials) Bukkit.getPluginManager().getPlugin("Essentials");
+        if (ess == null) {
+            plugin.getLogger().warning("Dreamvisitor cannot tax players today because Essentials is not enabled.");
+            return;
+        }
+        final BalanceTop balanceTop = ess.getBalanceTop();
+
+        int inactiveDays = config.getInt("daysUntilInactiveTax");
+        final BigDecimal percent = BigDecimal.valueOf(config.getDouble("inactiveTaxPercent"));
+        if (percent.equals(BigDecimal.ZERO)) {
+            plugin.getLogger().info("Tax percent is zero. Canceling");
+            return;
+        }
+        if (percent.compareTo(BigDecimal.ONE) > 0) {
+            plugin.getLogger().warning("Tax percent is greater than one. It must be between 0.0 and 1.0.");
+            return;
+        }
+        final BigDecimal minBalance = BigDecimal.valueOf(config.getInt("inactiveTaxStop"));
+
+        // Recalculate balance top.
+        balanceTop.calculateBalanceTopMapAsync().thenRun(() -> {
+            final Map<UUID, BalanceTop.Entry> balanceTopCache = balanceTop.getBalanceTopCache();
+            // Check each UUID
+            for (Map.Entry<UUID, BalanceTop.Entry> entry : balanceTopCache.entrySet()) {
+                final UUID uuid = entry.getKey();
+                try {
+
+                    // Get balance
+                    final BigDecimal balance = entry.getValue().getBalance();
+
+                    // Continue if balance is minimum or lower
+                    if (balance.compareTo(minBalance) <= 0) continue;
+
+                    // Get last online and continue if not inactive
+                    final Instant lastLogout = PlayerUtility.getLastLogout(uuid);
+                    final Duration durationSinceLastLogout =  Duration.between(lastLogout, Instant.now());
+                    if (durationSinceLastLogout.minusDays(inactiveDays).isNegative()) continue;
+
+                    // If inactive, calculate new amount
+                    BigDecimal newBalance = balance.subtract(balance.multiply(percent));
+
+                    // If new balance is less than minimum, set it to the minimum
+                    if (newBalance.compareTo(minBalance) < 0) newBalance = minBalance;
+
+                    // Save new balance
+                    ess.getUser(uuid).setMoney(newBalance);
+
+                } catch (Exception e) {
+                    // Essentials must be enabled to get to this point, so this should be impossible.
+                    plugin.getLogger().warning("Inactivity tax failed: " + e.getMessage());
+                    e.printStackTrace();
+                }
+            }
+
+            plugin.getLogger().info("Finished collecting inactivity taxes.");
+
+        });
     }
 
 }

--- a/dreamvisitor/src/main/resources/config.yml
+++ b/dreamvisitor/src/main/resources/config.yml
@@ -195,10 +195,14 @@ daysUntilInactiveTax: 60
 # Default: 0.1
 inactiveTaxPercent: 0.1
 
-# The time in days between inactivity taxes.
+# The time in days between inactivity taxes. 0 to disable.
 # Default: 7
 inactiveDayFrequency: 7
 
 # The lowest a balance can be depleted to by inactivity taxes.
 # Default: 50000
 inactiveTaxStop: 50000
+
+# The last time the inactive tax occurred. This should not be manually tampered with.
+# Default: 0
+lastInactiveTax: 0

--- a/dreamvisitor/src/main/resources/config.yml
+++ b/dreamvisitor/src/main/resources/config.yml
@@ -186,3 +186,19 @@ flightEnergyDepletionYMultiplier: 10.00
 # The message sent if a Wither is built in a region where the wither flag is denied.
 # Default: "Withers cannot be spawned here. You can only spawn Withers in the Wither chamber."
 noWitherNotice: "Withers cannot be spawned here. You can only spawn Withers in the Wither chamber."
+
+# The days a player can be offline until the inactivity tax applies.
+# Default: 60
+daysUntilInactiveTax: 60
+
+# The percent to tax inactive players, between 0.0 and 1.0
+# Default: 0.1
+inactiveTaxPercent: 0.1
+
+# The time in days between inactivity taxes.
+# Default: 7
+inactiveDayFrequency: 7
+
+# The lowest a balance can be depleted to by inactivity taxes.
+# Default: 50000
+inactiveTaxStop: 50000


### PR DESCRIPTION
Adds configurable inactivity taxes. The following has been added to `config.yml`:

```yaml
# The days a player can be offline until the inactivity tax applies.
# Default: 60
daysUntilInactiveTax: 60

# The percent to tax inactive players, between 0.0 and 1.0
# Default: 0.1
inactiveTaxPercent: 0.1

# The time in days between inactivity taxes. 0 to disable.
# Default: 7
inactiveDayFrequency: 7

# The lowest a balance can be depleted to by inactivity taxes.
# Default: 50000
inactiveTaxStop: 50000

# The last time the inactive tax occurred. This should not be manually tampered with.
# Default: 0
lastInactiveTax: 0
```

Parent issue #24 