### PR TITLE
Add energy modifiers and gliding thrusts

### DIFF
--- a/dreamvisitor/src/main/java/io/github/stonley890/dreamvisitor/listeners/ListenPlayerToggleFlightEvent.java
+++ b/dreamvisitor/src/main/java/io/github/stonley890/dreamvisitor/listeners/ListenPlayerToggleFlightEvent.java
@@ -37,7 +37,7 @@ public class ListenPlayerToggleFlightEvent implements Listener {
                         cancelWingFlapSoundTask(player);
 
                     } else {
-                        player.playSound(player.getLocation(), Sound.ENTITY_ENDER_DRAGON_FLAP, SoundCategory.PLAYERS, 0.5f, 1.2f);
+                        Flight.playWingFlapSound(player);
                     }
                 }, 1, 15));
 


### PR DESCRIPTION
This pull request focuses on changes to flight.

- While wearing elytra and not gliding, energy regenerates four times as fast.
- While wearing elytra and gliding, energy regenerates two times as fast.
- While equipped with 12 or more armor points, an additional energy penalty is added while flying.
- Pressing the jump button will perform a thrust while gliding, consuming some energy.